### PR TITLE
Feat/update assign

### DIFF
--- a/Definitions/policyAssignments/Security/configure-security-settings-on-arc-enabled-machines-assignments.jsonc
+++ b/Definitions/policyAssignments/Security/configure-security-settings-on-arc-enabled-machines-assignments.jsonc
@@ -11,12 +11,8 @@
         "displayName": "Configure Security Settings on Arc-enabled Machines"
     },
     "parameters": {
-        "CTI-DCR": {
-            "value": "/subscriptions/7d1bf03a-4afc-4b07-b713-e13090f1c6fd/resourceGroups/security-eu/providers/Microsoft.Insights/dataCollectionRules/Contoso-CT-DCR"
-        },
-        "SOC-DCR": {
-            "value": "/subscriptions/7d1bf03a-4afc-4b07-b713-e13090f1c6fd/resourceGroups/security-eu/providers/Microsoft.Insights/dataCollectionRules/SOC-DCR"
-        }
+        "CTI-DCR": "/subscriptions/7d1bf03a-4afc-4b07-b713-e13090f1c6fd/resourceGroups/security-eu/providers/Microsoft.Insights/dataCollectionRules/Contoso-CT-DCR",
+        "SOC-DCR": "/subscriptions/7d1bf03a-4afc-4b07-b713-e13090f1c6fd/resourceGroups/security-eu/providers/Microsoft.Insights/dataCollectionRules/SOC-DCR"
     },
     "scope": {
         "contoso-sandbox": [

--- a/Definitions/policyAssignments/Security/configure-security-settings-on-arc-enabled-machines-assignments.jsonc
+++ b/Definitions/policyAssignments/Security/configure-security-settings-on-arc-enabled-machines-assignments.jsonc
@@ -2,7 +2,7 @@
     "$schema": "https://raw.githubusercontent.com/Azure/enterprise-azure-policy-as-code/main/Schemas/policy-assignment-schema.json",
     "nodeName": "/arc-security/",
     "assignment": {
-        "name": "configure-security-settings-on-arc-enabled-machines",
+        "name": "security-settings-on-arc",
         "displayName": "Configure Security Settings on Arc-enabled Machines",
         "description": "Configure security settings on Azure Arc-enabled machines, including installing Azure Monitor Agent, configuring Change Tracking & Inventory VM extension and DCR, and DCR for SOC."
     },

--- a/Definitions/policyAssignments/Security/configure-security-settings-on-arc-enabled-machines-assignments.jsonc
+++ b/Definitions/policyAssignments/Security/configure-security-settings-on-arc-enabled-machines-assignments.jsonc
@@ -20,7 +20,7 @@
     },
     "scope": {
         "contoso-sandbox": [
-            "//providers/Microsoft.Management/managementGroups/Sandbox"
+            "/providers/Microsoft.Management/managementGroups/Sandbox"
         ],
         "contoso-prod": [
             "/providers/Microsoft.Management/managementGroups/IntermediateContoso"

--- a/Definitions/policyAssignments/Security/configure-security-settings-on-arc-enabled-machines-assignments.jsonc
+++ b/Definitions/policyAssignments/Security/configure-security-settings-on-arc-enabled-machines-assignments.jsonc
@@ -7,8 +7,8 @@
         "description": "Configure security settings on Azure Arc-enabled machines, including installing Azure Monitor Agent, configuring Change Tracking & Inventory VM extension and DCR, and DCR for SOC."
     },
     "definitionEntry": {
-        "policySetName": "e14e5d7c-9551-4ae2-b8fa-b5d6b9b3c677",
-        "displayName": "Allowed Locations Initiative"
+        "policySetName": "configure-security-settings-on-arc-enabled-machines",
+        "displayName": "Configure Security Settings on Arc-enabled Machines"
     },
     "parameters": {
         "CTI-DCR": {

--- a/Definitions/policyAssignments/Security/configure-security-settings-on-arc-enabled-machines-assignments.jsonc
+++ b/Definitions/policyAssignments/Security/configure-security-settings-on-arc-enabled-machines-assignments.jsonc
@@ -1,0 +1,29 @@
+﻿{
+    "$schema": "https://raw.githubusercontent.com/Azure/enterprise-azure-policy-as-code/main/Schemas/policy-assignment-schema.json",
+    "nodeName": "/arc-security/",
+    "assignment": {
+        "name": "configure-security-settings-on-arc-enabled-machines",
+        "displayName": "Configure Security Settings on Arc-enabled Machines",
+        "description": "Configure security settings on Azure Arc-enabled machines, including installing Azure Monitor Agent, configuring Change Tracking & Inventory VM extension and DCR, and DCR for SOC."
+    },
+    "definitionEntry": {
+        "policySetName": "e14e5d7c-9551-4ae2-b8fa-b5d6b9b3c677",
+        "displayName": "Allowed Locations Initiative"
+    },
+    "parameters": {
+        "CTI-DCR": {
+            "value": "/subscriptions/7d1bf03a-4afc-4b07-b713-e13090f1c6fd/resourceGroups/security-eu/providers/Microsoft.Insights/dataCollectionRules/Contoso-CT-DCR"
+        },
+        "SOC-DCR": {
+            "value": "/subscriptions/7d1bf03a-4afc-4b07-b713-e13090f1c6fd/resourceGroups/security-eu/providers/Microsoft.Insights/dataCollectionRules/SOC-DCR"
+        }
+    },
+    "scope": {
+        "contoso-sandbox": [
+            "//providers/Microsoft.Management/managementGroups/Sandbox"
+        ],
+        "contoso-prod": [
+            "/providers/Microsoft.Management/managementGroups/IntermediateContoso"
+        ]
+    }
+}


### PR DESCRIPTION
This pull request introduces a new policy assignment configuration for security settings on Azure Arc-enabled machines. The changes include defining the policy assignment schema, specifying the policy set name, and detailing the parameters and scope for the assignment.

Key changes:

* Added a new policy assignment configuration in `Definitions/policyAssignments/Security/configure-security-settings-on-arc-enabled-machines-assignments.jsonc`:
  * Defined the schema and node name.
  * Specified the assignment details, including name, display name, and description.
  * Included the policy set name and display name in the definition entry.
  * Detailed the parameters for CTI-DCR and SOC-DCR.
  * Defined the scope for `contoso-sandbox` and `contoso-prod` management groups.