### PR TITLE
Fix typo in global settings management group name

### DIFF
--- a/Definitions/global-settings.jsonc
+++ b/Definitions/global-settings.jsonc
@@ -13,7 +13,7 @@
                 "doNotDisableDeprecatedPolicies": false
             },
             "globalNotScopes": [
-                "/providers/Microsoft.Management/managementGroups/Decomissioned"
+                "/providers/Microsoft.Management/managementGroups/Decommissioned"
             ],
             "managedIdentityLocation": "westeurope"
         },


### PR DESCRIPTION
This pull request includes a small but important change to the `Definitions/global-settings.jsonc` file. The change corrects a typo in the `globalNotScopes` array.

* [`Definitions/global-settings.jsonc`](diffhunk://#diff-ea505f74254d2b4fcd79fb320cdca6819a765d0ff7a59b6ba833fd0fbd4d062dL16-R16): Corrected the spelling of "Decommissioned" from "Decomissioned" in the `globalNotScopes` array.