### PR TITLE
Feat/fix decommissioned

### DIFF
--- a/Definitions/global-settings.jsonc
+++ b/Definitions/global-settings.jsonc
@@ -12,7 +12,6 @@
                 "keepDfcSecurityAssignments": true, // default false
                 "doNotDisableDeprecatedPolicies": false
             },
-            "globalNotScopes": [],
             "managedIdentityLocation": "westeurope"
         },
         {
@@ -25,7 +24,6 @@
                 "keepDfcSecurityAssignments": true, // default false // default full
                 "doNotDisableDeprecatedPolicies": false
             },
-            "globalNotScopes": [],
             "managedIdentityLocation": "westeurope"
         }
     ]

--- a/Definitions/policyAssignments/Decommissioned/ALZ-Decommissioned-Default.jsonc
+++ b/Definitions/policyAssignments/Decommissioned/ALZ-Decommissioned-Default.jsonc
@@ -11,6 +11,7 @@
             "nodeName": "Guardrails",
             "assignment": {
                 "name": "Enforce-ALZ-Decomm",
+                "append": true,
                 "displayName": "Enforce ALZ Decommissioned Guardrails",
                 "description": "This initiative will help enforce and govern subscriptions that are placed within the decommissioned Management Group as part of your Subscription decommissioning process. See https://aka.ms/alz/policies for more information."
             },

--- a/Definitions/policyAssignments/Security/configure-security-settings-on-arc-enabled-machines-assignments.jsonc
+++ b/Definitions/policyAssignments/Security/configure-security-settings-on-arc-enabled-machines-assignments.jsonc
@@ -83,9 +83,11 @@
                     "/providers/Microsoft.Management/managementGroups/IntermediateContoso"
                 ]
             },
-            "notScope": [
-                "/providers/Microsoft.Management/managementGroups/Decommissioned"
-            ]
+            "notScope": {
+                "contoso-prod": [
+                    "/providers/Microsoft.Management/managementGroups/Decommissioned"
+                ]
+            }
         }
     ]
 }


### PR DESCRIPTION
This pull request includes several changes to the JSONC configuration files for policy assignments and global settings. The most important changes are focused on modifying the structure and attributes of these configurations.

Changes to `global-settings.jsonc`:

* Removed the `globalNotScopes` attribute from the global settings configuration. [[1]](diffhunk://#diff-ea505f74254d2b4fcd79fb320cdca6819a765d0ff7a59b6ba833fd0fbd4d062dL15) [[2]](diffhunk://#diff-ea505f74254d2b4fcd79fb320cdca6819a765d0ff7a59b6ba833fd0fbd4d062dL28)

Changes to policy assignment configurations:

* Added the `append` attribute to the `assignment` object in the `ALZ-Decommissioned-Default.jsonc` file to ensure the policy is appended.
* Modified the `notScope` attribute in the `configure-security-settings-on-arc-enabled-machines-assignments.jsonc` file to use an object instead of an array, and added a new entry for `contoso-prod`.