### PR TITLE
Fix naming conventions in security settings assignments for Azure Arc…

### DIFF
--- a/Definitions/policyAssignments/Security/configure-security-settings-on-arc-enabled-machines-assignments.jsonc
+++ b/Definitions/policyAssignments/Security/configure-security-settings-on-arc-enabled-machines-assignments.jsonc
@@ -6,7 +6,7 @@
         "displayName": "Configure Security Settings on Arc-enabled Machines",
         "assignment": {
             "append": true,
-            "name": "arc-settings-on",
+            "name": "arc-settings",
             "displayName": "Azure Arc custom Initiative",
             "description": "Configure security settings on Azure Arc-enabled machines"
         },
@@ -61,7 +61,7 @@
         {
             "nodeName": "Sandbox/",
             "assignment": {
-                "name": "-sbx",
+                "name": "sbx-",
                 "displayName": "Sandbox ",
                 "description": "Sandbox Arc-connected machines controls enforcement with "
             },
@@ -74,7 +74,7 @@
         {
             "nodeName": "Prod/",
             "assignment": {
-                "name": "-prd",
+                "name": "prd-",
                 "displayName": "Prod ",
                 "description": "Prod Arc-connected machines controls enforcement with "
             },


### PR DESCRIPTION
This pull request includes changes to the `Definitions/policyAssignments/Security/configure-security-settings-on-arc-enabled-machines-assignments.jsonc` file to standardize the naming conventions for policy assignments. The most important changes include renaming assignment names to follow a consistent format.

Standardization of naming conventions:

* Renamed the assignment name from `arc-settings-on` to `arc-settings`.
* Updated the assignment name from `-sbx` to `sbx-` for the Sandbox node.
* Changed the assignment name from `-prd` to `prd-` for the Prod node.…-enabled machines