### PR TITLE
Feat/add deployment script for sandbox and production environments

### DIFF
--- a/operations/plan and deploy.ps1
+++ b/operations/plan and deploy.ps1
@@ -1,0 +1,11 @@
+﻿# Build and deploy the plans for the sandbox and production environments
+Build-DeploymentPlans -PacEnvironmentSelector 'contoso-sandbox' -DefinitionsRootFolder '.\Definitions' -OutputFolder '.\Output'
+Build-DeploymentPlans -PacEnvironmentSelector 'contoso-prod' -DefinitionsRootFolder '.\Definitions' -OutputFolder '.\Output'
+
+# Deploy the policies for the sandbox and production environments
+Deploy-PolicyPlan -PacEnvironmentSelector 'contoso-sandbox' -DefinitionsRootFolder '.\Definitions'
+Deploy-PolicyPlan -PacEnvironmentSelector 'contoso-prod' -DefinitionsRootFolder '.\Definitions'
+
+# Deploy the roles for the sandbox and production environments
+Deploy-RolesPlan -PacEnvironmentSelector 'contoso-sandbox' -DefinitionsRootFolder '.\Definitions'
+Deploy-RolesPlan -PacEnvironmentSelector 'contoso-prod' -DefinitionsRootFolder '.\Definitions'


### PR DESCRIPTION
This pull request introduces a new script to automate the building and deployment of plans, policies, and roles for both the sandbox and production environments. The changes are focused on the `operations/plan and deploy.ps1` file.

Key changes include:

* Added commands to build deployment plans for sandbox and production environments using `Build-DeploymentPlans`.
* Added commands to deploy policies for sandbox and production environments using `Deploy-PolicyPlan`.
* Added commands to deploy roles for sandbox and production environments using `Deploy-RolesPlan`.